### PR TITLE
Critical bug fix

### DIFF
--- a/chkdomain_status.sh
+++ b/chkdomain_status.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-while read LINE; do
-  curl -o "$LINE" --silent --head --write-out "%{http_code} $LINE\n" "$LINE"
-done < "$1"

--- a/modules/crawler.py
+++ b/modules/crawler.py
@@ -39,7 +39,7 @@ def crawler(target, output, data):
 	print('\n' + Y + '[!]' + Y + ' Starting Crawler...' + W + '\n')
 
 	try:
-		rqst = requests.get(target, headers=user_agent, verify=False, timeout=10)
+		rqst = requests.get(target, headers=user_agent, verify=True, timeout=10)
 	except Exception as e:
 		print(R + '[-] Exception : ' + C + str(e) + W)
 		exit()

--- a/recon_bulk.sh
+++ b/recon_bulk.sh
@@ -8,4 +8,4 @@ do
 	python3 finalrecon.py --headers https://$domain -o csv
 IFS=$oldIFS
 done < "$1"
-#IFS=$oldIFS
+


### PR DESCRIPTION
Certificate verification is disabled by setting verify to False in requests.get. This may lead to Man-in-the-middle attacks.